### PR TITLE
Fix memory leak in deep_main.

### DIFF
--- a/include/deep_interp.h
+++ b/include/deep_interp.h
@@ -36,10 +36,11 @@ typedef struct DEEPExecEnv {
 //创建操作数栈
 DEEPStack *stack_cons(void);
 
+//销毁操作数栈
+void stack_free(DEEPStack *stack);
+
 int32_t call_main(DEEPExecEnv *current_env, DEEPModule *module);
 
 void call_function(DEEPExecEnv *current_env, DEEPModule *module, int func_index);
 
 #endif /* _DEEP_INTERP_H */
-
-

--- a/include/deep_loader.h
+++ b/include/deep_loader.h
@@ -29,16 +29,16 @@
 //type item
 typedef struct DEEPType
 {
-    int32_t param_count;
-    int32_t ret_count;
+    uint32_t param_count;
+    uint32_t ret_count;
     uint8_t type[1];
 } DEEPType;
 
 //local variables item
 typedef struct LocalVars
 {
-    int32_t count;
-    int16_t local_type;
+    uint32_t count;
+    uint8_t local_type;
 } LocalVars;
 
 //function item
@@ -46,7 +46,7 @@ typedef struct DEEPFunction
 {
     DEEPType *func_type; // the type of function
     LocalVars **localvars;
-    int32_t code_size;
+    uint32_t code_size;
     uint8_t *code_begin;
 } DEEPFunction;
 
@@ -54,15 +54,15 @@ typedef struct DEEPFunction
 typedef struct DEEPExport
 {
     char* name;
-    int32_t index;
+    uint32_t index;
     char tag;
 } DEEPExport;
 
 //
 typedef struct DEEPData
 {
-    int32_t offset;
-    int32_t datasize;
+    uint32_t offset;
+    uint32_t datasize;
     uint8_t *data;
 } DEEPData;
 
@@ -70,10 +70,10 @@ typedef struct DEEPData
 two sections, which can make the program run*/
 typedef struct DEEPModule
 {
-    int32_t type_count;
-    int32_t function_count;
-    int32_t export_count;
-    int32_t data_count;
+    uint32_t type_count;
+    uint32_t function_count;
+    uint32_t export_count;
+    uint32_t data_count;
     DEEPType **type_section;
     DEEPFunction **func_section;
     DEEPExport **export_section;
@@ -90,6 +90,7 @@ typedef struct section_listnode
 } section_listnode;
 
 DEEPModule* deep_load(uint8_t** p, int32_t size);
+void module_free(DEEPModule *module);
 uint32_t read_leb_u32(uint8_t** p);
 int32_t read_leb_i32(uint8_t** p);
 uint8_t* init_memory(uint32_t min_page);

--- a/src/deep_interp.c
+++ b/src/deep_interp.c
@@ -40,6 +40,12 @@ DEEPStack *stack_cons(void) {
     return stack;
 }
 
+//销毁操作数栈
+void stack_free(DEEPStack *stack) {
+    free(stack->sp);
+    free(stack);
+}
+
 //执行代码块指令
 void exec_instructions(DEEPExecEnv *current_env, DEEPModule *module) {
     uint32_t *sp = current_env->cur_frame->sp;
@@ -279,14 +285,14 @@ void call_function(DEEPExecEnv *current_env, DEEPModule *module, int func_index)
 
     //函数类型
     DEEPType *deepType = func->func_type;
-    int param_num = deepType->param_count;
-    int ret_num = deepType->ret_count;
+    uint32_t param_num = deepType->param_count;
+    uint32_t ret_num = deepType->ret_count;
 
 //    current_env->sp-=param_num;//操作数栈指针下移
     current_env->local_vars = (uint32_t *) malloc(sizeof(uint32_t) * param_num);
-    int vars_temp = param_num;
+    uint32_t vars_temp = param_num;
     while (vars_temp > 0) {
-        int temp = *(--current_env->sp);
+        uint32_t temp = *(--current_env->sp);
         current_env->local_vars[(vars_temp--) - 1] = temp;
     }
 
@@ -324,8 +330,8 @@ int32_t call_main(DEEPExecEnv *current_env, DEEPModule *module) {
     //create DEEPFunction for main
     //find the index of main
     int main_index = -1;
-    int export_count = module->export_count;
-    for (int i = 0; i < export_count; i++) {
+    uint32_t export_count = module->export_count;
+    for (uint32_t i = 0; i < export_count; i++) {
         if (strcmp((module->export_section[i])->name, "main") == 0) {
             main_index = module->export_section[i]->index;
         }

--- a/src/deep_main.c
+++ b/src/deep_main.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
 #include "deep_interp.h"
 #include "deep_loader.h"
 #include "deep_log.h"
@@ -16,6 +17,7 @@ int32_t main(int argv, char **args) {
         path = args[1];
     }
     uint8_t *q = (uint8_t *) malloc(WASM_FILE_SIZE);
+    memset(q, 0, WASM_FILE_SIZE); // Suppress valgrind warning
     uint8_t *p = q;
     if (p == NULL) {
         error("malloc fail.");
@@ -53,9 +55,10 @@ int32_t main(int argv, char **args) {
 
     /* release memory */
     fclose(fp);
-    free(stack);
-    free(module);
+    stack_free(stack);
+    module_free(module);
     free(current_env->global_vars);
+    free(current_env->memory);
     free(q);
     p = NULL;
     return 0;


### PR DESCRIPTION
Fix memory leak in deep_main (tested with valgrind)
1. Implement specific free functions for DEEPStack & DEEPModule.
2. Change int32_t to uint32_t consistently when applicable.