### PR TITLE
Fix issue 20

### DIFF
--- a/include/deep_interp.h
+++ b/include/deep_interp.h
@@ -24,6 +24,7 @@ typedef struct DEEPInterpFrame {
     struct DEEPFunction *function; //当前函数实例
     uint32_t *sp; //操作数栈指针
     DEEPFrameType type; //类型
+    uint32_t *local_vars; //局部变量
 } DEEPInterpFrame;
 
 //操作数栈

--- a/include/deep_loader.h
+++ b/include/deep_loader.h
@@ -37,18 +37,18 @@ typedef struct DEEPType
     uint8_t *type;
 } DEEPType;
 
-//local variables item
-typedef struct LocalVars
+// Storage of local variable information in DEEPFunction
+typedef struct LocalVarCluster
 {
     uint32_t count;
     uint8_t local_type;
-} LocalVars;
+} LocalVarCluster;
 
 //function item
 typedef struct DEEPFunction
 {
     DEEPType *func_type; // the type of function
-    LocalVars **local_vars;
+    LocalVarCluster *local_var_types; // Local variables' type informations
     uint32_t code_size;
     uint8_t *code_begin;
     uint8_t local_vars_count;


### PR DESCRIPTION
在`DEEPInterpFrame`中引入了`local_vars`，用于存储当前函数帧对应的本地变量。换言之，现在“本地变量”这个与当前函数相关的结构的管理权已经交给了函数帧，`DEEPEnv`里的`local_vars`只不过是函数帧里的本地变量的一个reference。

当函数帧被创造时，就会给本地变量分配空间；函数帧被销毁时，也会销毁本地变量。不同函数的本地变量不会相互覆盖。

能顺利通过所有test，并且没有memory leak。