### PR TITLE
Deepvm的segfault问题

### DIFF
--- a/src/deep_main.c
+++ b/src/deep_main.c
@@ -66,7 +66,7 @@ int32_t main(int argv, char **args) {
     current_env->jump_depth = 0;
     int64_t ans = call_main(current_env, module);
 
-    printf("%lld\n", ans);
+    printf("%ld\n", ans);
     fflush(stdout);
 
     /* release memory */


### PR DESCRIPTION
来源于deeploader中一个错误的offset设定，导致给native函数的local variables分配空间时总是会只分配0byte
主要改动刚才忘记开新branch都在dev上了，我有罪orz
在mac和linux上都测试通过

TODO：
1. 给deep_loader.c添加更多注释，提升可读性和可维护性
2. 修复deepmem的内存泄漏（漏了一点点，目前还没查原因