### PR TITLE
Memleak问题

### DIFF
--- a/include/deep_log.h
+++ b/include/deep_log.h
@@ -28,7 +28,7 @@ Description: head file of dump/debug funtions for logs
 #ifndef _DEEP_LOG_H
 #define _DEEP_LOG_H
 
-// #define DEBUG
+#define DEBUG
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -46,7 +46,7 @@ void log_data(const char *pFileName, unsigned int uiLine, const char* pFuncName,
 #define deep_info(...)                              log_printf(__FILE__, __LINE__,__FUNCTION__,"<info>",__VA_ARGS__)
 #define deep_dump(pcStr,pucBuf,usLen)               log_data(__FILE__, __LINE__,__FUNCTION__,pcStr,pucBuf,usLen)
 
-// #define DBG
+#define DBG
 #ifdef DBG
 #define PRINT_ARG(FSTRING, ARG) do {printf(FSTRING, ARG); fflush(stdout);} while (0)
 #else

--- a/include/deep_log.h
+++ b/include/deep_log.h
@@ -28,7 +28,7 @@ Description: head file of dump/debug funtions for logs
 #ifndef _DEEP_LOG_H
 #define _DEEP_LOG_H
 
-#define DEBUG
+// #define DEBUG
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -46,7 +46,7 @@ void log_data(const char *pFileName, unsigned int uiLine, const char* pFuncName,
 #define deep_info(...)                              log_printf(__FILE__, __LINE__,__FUNCTION__,"<info>",__VA_ARGS__)
 #define deep_dump(pcStr,pucBuf,usLen)               log_data(__FILE__, __LINE__,__FUNCTION__,pcStr,pucBuf,usLen)
 
-#define DBG
+// #define DBG
 #ifdef DBG
 #define PRINT_ARG(FSTRING, ARG) do {printf(FSTRING, ARG); fflush(stdout);} while (0)
 #else

--- a/include/deep_mem.h
+++ b/include/deep_mem.h
@@ -93,4 +93,7 @@ void *deep_realloc (void *ptr, uint32_t size);
 void deep_free (void *ptr);
 bool deep_mem_migrate (void *new_mem, uint32_t size);
 
+// For debugging; get the free memory in the pool
+uint64_t deep_get_free_memory(void);
+
 #endif /* _DEEP_MEM_ALLOC_H */

--- a/src/deep_interp.c
+++ b/src/deep_interp.c
@@ -410,6 +410,10 @@ bool exec_instructions(DEEPExecEnv *current_env, DEEPModule *module) {
                         opcode == op_block ? BLOCK_FRAME : LOOP_FRAME);
                 sp = current_env->sp;
                 //释放空间
+                //如果有个返回值，需要释放返回值的类型
+                if (type->ret_count == 1) {
+                    deep_free(type->type);
+                }
                 deep_free(type);
                 deep_free(block);
                 break;
@@ -461,6 +465,10 @@ bool exec_instructions(DEEPExecEnv *current_env, DEEPModule *module) {
                 }
                 sp = current_env->sp;
                 //释放空间
+                //如果有个返回值，需要释放返回值的类型
+                if (type->ret_count == 1) {
+                    deep_free(type->type);
+                }
                 deep_free(type);
                 deep_free(block);
                 break;

--- a/src/deep_loader.c
+++ b/src/deep_loader.c
@@ -480,7 +480,6 @@ static void decode_each_sections(DEEPModule* module, section_listnode* section_l
             break;
         case SECTION_TYPE_DATA:
             decode_data_section(buf, module);
-
             break;
         default:
 

--- a/src/deep_main.c
+++ b/src/deep_main.c
@@ -23,6 +23,9 @@ int32_t main(int argv, char **args) {
     // 初始化deepmem
     deep_mem_init(deepmem, MEM_SIZE);
 
+    // 测试用：获取当前空闲内存数量
+    uint64_t free_mem = deep_get_free_memory();
+
     char *path;
     if(argv==1){
         deep_error("no file input!");
@@ -78,5 +81,11 @@ int32_t main(int argv, char **args) {
     deep_free(current_env->memory);
     deep_free(q);
     p = NULL;
+
+    // 测试用：如果结束时空闲内存数量不变，说明没有内存泄漏
+    if (free_mem != deep_get_free_memory()) {
+        deep_error("memory leak!");
+        return -1;
+    }
     return 0;
 }

--- a/src/deep_mem.c
+++ b/src/deep_mem.c
@@ -7,7 +7,7 @@
 #include "deep_log.h"
 #include "deep_mem.h"
 
-// #define REVERT_TO_DEFAULT_MEMORY_MANAGEMENT
+#define REVERT_TO_DEFAULT_MEMORY_MANAGEMENT
 
 #ifdef REVERT_TO_DEFAULT_MEMORY_MANAGEMENT
 #include "stdlib.h"
@@ -175,6 +175,9 @@ deep_mem_destroy (void)
 void *
 deep_malloc(uint32_t size)
 {
+  if (size == 16) {
+    puts("16!");
+  }
   void *result = malloc(size);
   memset(result, 0, size);
   return result;

--- a/src/deep_mem.c
+++ b/src/deep_mem.c
@@ -698,3 +698,6 @@ static void _remove_sorted_block_from_skiplist (sorted_block_t *block)
   /* no other cases, as if it is the first node, it should be the only node. */
 }
 
+uint64_t deep_get_free_memory(void) {
+  return pool->free_memory;
+}

--- a/src/deep_mem.c
+++ b/src/deep_mem.c
@@ -175,9 +175,6 @@ deep_mem_destroy (void)
 void *
 deep_malloc(uint32_t size)
 {
-  if (size == 16) {
-    puts("16!");
-  }
   void *result = malloc(size);
   memset(result, 0, size);
   return result;

--- a/test/test.py
+++ b/test/test.py
@@ -1,7 +1,16 @@
+import platform
 import subprocess
 
 
 def test_with_path(path, expected=None, returncode=0):
+    # # Check memory leak using "leaks" on Apple Chip
+    # if (platform.system() == 'Darwin' and platform.processor() == 'arm'):
+    #     try:
+    #         subprocess.check_call(
+    #             ['leaks', '--atExit', '--', '../bin/deepvm', path], stdout=subprocess.DEVNULL)
+    #     except subprocess.CalledProcessError as e:
+    #         print(f"FAIL: {path} failed memory leak test!")
+
     try:
         actual = subprocess.check_output(
             ['../bin/deepvm', path]).decode('utf-8').strip().replace('\r\n', '\n')


### PR DESCRIPTION
问题：
1. 使用deepmem时，通过fast block获得的内存在free的时候都不会被free成功
2. 部分用例指令即使切回原生内存管理也存在内存泄漏

原因：
1. 分配fast block时会将新获得的内存memset成0，而set的大小有误，会把下一个block的flag清除，导致free的时候会以为该block已经被free掉了。已经修复成正确的大小
2. 使用block时，如果block有返回值，存这个返回值type的空间被忘记被free了。已经修复

其他：
1. 添加了Mac Apple Chip上的内存泄漏测试用例（在test.py中，默认是注释掉的）。可以用来检测interpreter的代码逻辑是否存在内存泄漏（也就是deep_malloc完忘记deep_free的情况）。必须在M1/M2芯片上关掉deepmem才能使用（deep_mem.c中取消注释`// #define REVERT_TO_DEFAULT_MEMORY_MANAGEMENT`）
2. 在程序结束时检查deepmem剩余空间是否和开始时的剩余空间一致，若否，则存在内存泄漏